### PR TITLE
make types available outside of package

### DIFF
--- a/packages/ryanair/source/flights/types.ts
+++ b/packages/ryanair/source/flights/types.ts
@@ -44,7 +44,7 @@ export const Segment = z.object({
   duration: z.string()
 })
 
-export const Fare = z.object({
+const Fare = z.object({
   type: z.string(),
   amount: z.number(),
   count: z.number(),

--- a/packages/ryanair/source/index.ts
+++ b/packages/ryanair/source/index.ts
@@ -1,3 +1,6 @@
 export * as airports from '~/airports/index.ts'
+export * from '~/airports/types.ts'
 export * as fares from '~/fares/index.ts'
+export * from '~/fares/types.ts'
 export * as flights from '~/flights/index.ts'
+export * from '~/flights/types.ts'


### PR DESCRIPTION
I think it would be useful to be able to import the types created by the package.
For example, to type an array of Airports fetched on the backend using the types on the frontend.

https://github.com/2BAD/ryanair/issues/70