### PR TITLE
sync template baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,8 @@ on:
 
 jobs:
   build:
-    name: build on node@${{ matrix.node-version }}
+    name: build
     runs-on: blacksmith-4vcpu-ubuntu-2404
-
-    strategy:
-      matrix:
-        node-version:
-          - 24
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -23,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: package.json
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,11 @@ on:
 
 jobs:
   test:
-    name: test on ${{ matrix.os-release }} node@${{ matrix.node-version }}
+    name: test on ${{ matrix.os-release }}
     runs-on: ${{ matrix.os-release }}
 
     strategy:
       matrix:
-        node-version:
-          - 24
         os-release:
           - blacksmith-4vcpu-ubuntu-2404
           - blacksmith-4vcpu-windows-2025
@@ -28,7 +26,7 @@ jobs:
       - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: package.json
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -15,20 +15,14 @@
     "publint": "0.3.18",
     "tsdown": "0.21.10",
     "typescript": "6.0.3",
-    "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.5"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.0.9",
   "engines": {
-    "node": ">=24"
+    "node": ">=26"
   },
   "volta": {
-    "node": "24.15.0",
-    "pnpm": "10.33.2"
+    "node": "26.1.0",
+    "pnpm": "11.0.9"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -66,6 +66,6 @@
     "@types/tough-cookie": "4.0.5"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=26"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -68,6 +68,6 @@
     "@modelcontextprotocol/inspector": "0.21.2"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=26"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      vite-tsconfig-paths:
-        specifier: 6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0))
       vitest:
         specifier: 4.1.5
         version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0))
@@ -1568,9 +1565,6 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2358,16 +2352,6 @@ packages:
       '@swc/wasm':
         optional: true
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsdown@0.21.10:
     resolution: {integrity: sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==}
     engines: {node: '>=20.19.0'}
@@ -2474,11 +2458,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -3955,8 +3934,6 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  globrex@0.1.2: {}
-
   gopd@1.2.0: {}
 
   got@14.6.6:
@@ -4707,10 +4684,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
   tsdown@0.21.10(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
@@ -4789,16 +4762,6 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
-
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.0.10(@types/node@25.6.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@8.0.10(@types/node@25.6.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
   - packages/*
+
+allowBuilds:
+  esbuild: true

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { coverageConfigDefaults, defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    tsconfigPaths: true
+  },
   test: {
     exclude: ['**/build/**', '**/node_modules/**'],
     coverage: {
@@ -11,6 +13,5 @@ export default defineConfig({
     },
     testTimeout: 30000,
     retry: process.env['CI'] ? 2 : 0
-  },
-  plugins: [tsconfigPaths()]
+  }
 })


### PR DESCRIPTION
## Summary
Sync recent `ts-lib-starter` template changes into this monorepo:

- Migrate to pnpm 11.0.9 (`packageManager`, `volta.pnpm`)
- Move `pnpm.onlyBuiltDependencies` from root `package.json` -> `pnpm-workspace.yaml` `allowBuilds:` (the `pnpm` field is removed in v11)
- Bump Node to 26 (`engines.node` on root + both packages, `volta.node`)
- Stable CI check names (`build`, `test on <os>`); workflows read node from `package.json` via `node-version-file:`
- Drop `vite-tsconfig-paths`; vitest uses native `resolve.tsconfigPaths: true`

`publish.yml` already uses `pnpm -r publish --provenance` so no change needed there. Renovate-tracked dep bumps (oxfmt/oxlint/publint/tsdown to latest) are intentionally left for renovate's next sweep.

Branch protection contexts will be PATCHed to the new names before merge.

## Test plan
- [x] `pnpm install` clean on pnpm 11.0.9
- [x] `pnpm run -r check` passes (11 pre-existing oxlint warnings in client)
- [x] `pnpm run -r build` passes (attw + publint clean for both packages)
- [x] `pnpm run -r test` passes (69 tests in client; mcp uses `exit 0` placeholder)
- [ ] CI green