### PR TITLE
fix availability auth and drop unused tough-cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ const deals = await fares.getCheapestPerDay('BER', 'DUB', '2024-02-01')
 
 ## Notes on the booking API
 
-`flights.getAvailable()` hits `/api/booking/v4/*/availability`, which performs a weak presence check on a `fr-correlation-id` cookie and a `client-version` header that must match a currently-deployed Ryanair web client version. This package self-issues the cookie and ships a known-good `client-version` value (currently `3.196.0`).
+`flights.getAvailable()` calls `/api/booking/v4/*/availability`. The endpoint checks for a `fr-correlation-id` cookie (any value works, only the presence matters) and a `client-version` header matching a current Ryanair web build. The package generates the cookie itself and defaults `client-version` to `3.196.0`.
 
-If Ryanair retires that version from their whitelist, `getAvailable()` will start returning `409 Availability declined`. To recover, find the current version (open ryanair.com in a browser, look at any availability XHR's `client-version` request header in DevTools) and set it before importing the package:
+When Ryanair drops that version, `getAvailable()` starts returning `409 Availability declined`. Grab a current value from ryanair.com (open DevTools, find any availability XHR, copy its `client-version` request header) and override:
 
 ```shell
 RYANAIR_CLIENT_VERSION=3.197.0 node app.js
 ```
 
-All other endpoints (airports, fares, flight dates and schedules) require no authentication.
+The other endpoints (airports, fares, flight dates, schedules) don't need any auth.
 
 ## Understanding IATA Codes
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ const deals = await fares.getCheapestPerDay('BER', 'DUB', '2024-02-01')
 
 [View Flights Documentation →](docs/flights.md)
 
+## Notes on the booking API
+
+`flights.getAvailable()` hits `/api/booking/v4/*/availability`, which performs a weak presence check on a `fr-correlation-id` cookie and a `client-version` header that must match a currently-deployed Ryanair web client version. This package self-issues the cookie and ships a known-good `client-version` value (currently `3.196.0`).
+
+If Ryanair retires that version from their whitelist, `getAvailable()` will start returning `409 Availability declined`. To recover, find the current version (open ryanair.com in a browser, look at any availability XHR's `client-version` request header in DevTools) and set it before importing the package:
+
+```shell
+RYANAIR_CLIENT_VERSION=3.197.0 node app.js
+```
+
+All other endpoints (airports, fares, flight dates and schedules) require no authentication.
+
 ## Understanding IATA Codes
 
 IATA codes are three-letter identifiers used in aviation for airports worldwide. For example:

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,11 +59,7 @@
     "fast-cartesian": "9.0.1",
     "got": "15.0.5",
     "hpagent": "1.2.0",
-    "tough-cookie": "6.0.1",
     "zod": "4.4.3"
-  },
-  "devDependencies": {
-    "@types/tough-cookie": "4.0.5"
   },
   "engines": {
     "node": ">=26"

--- a/packages/client/source/client/index.ts
+++ b/packages/client/source/client/index.ts
@@ -1,8 +1,15 @@
+import { randomUUID } from 'node:crypto'
 import got, { type Agents, type Got } from 'got'
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent'
 import { debounce } from '~/client/hooks/debounce.ts'
 
 export const DELAY_MS: number | [number, number] = 500
+
+// Booking API gates on a `fr-correlation-id` cookie (presence only, value unchecked)
+// and a `client-version` header that must match a currently-deployed Ryanair web
+// client version. Override the version via `RYANAIR_CLIENT_VERSION` when the default
+// gets retired from their whitelist; symptom is `409 Availability declined`.
+const CLIENT_VERSION = process.env['RYANAIR_CLIENT_VERSION'] ?? '3.196.0'
 
 /**
  * Create proxy agents if proxy environment variables are set
@@ -21,18 +28,11 @@ const createProxyAgents = (): Agents => {
   return {}
 }
 
-/**
- * Extend `got` http client so every time request is made there is a `rid.sig` cookie
- * that is needed for certain endpoints to work
- *
- * @returns A promise that resolves with the response data or rejects with an error
- */
-
 export const get: Got = got.extend({
   headers: {
-    client: 'desktop',
-    cookie:
-      'fr-correlation-id=510176ee-3585-4b17-9bcc-a2dba963cb16; rid=167bf904-3ee1-497b-9bd4-2e4416cf2145; rid.sig=RrjjHNquuQZkrfRiOnO9aCGeAnjLsMy3s6531/IPqU6a/CKaRWXjzARlMYE4iCiWdPA/+isg34kP7bjS45qKI/gPDLqNSJXTzZ1bRR4Oqj+xyWQ16gsHVzyQ2ch2vvayIRv4x5VM6iUMCUp3vIdFeXSUdjMc+dPt3QEgeojLqQlmjSGIB7aW2qEogx6rUujq13TVjh6GRp66G/FfDMIVTEbvyK9C19r7qujUptGjzslAUigUdvoCwLRqNmAFj8M76grc3g/MGAT5/dV4tpPr8eYX5/Lb/y9MdLfCWhlSK9qWayhHQmVAlNIeuXNNmLmeLIMllhslSHGGyl5w/yi2EX9nHULYBoqkG75O8d7/m1+wZven97H0JjuK4uRwac4ubzTsY8Mr6UShaVIcwCYrDQ==; xid=d3772090-c923-4c81-89c5-697279c6d1ad;'
+    'user-agent': 'Mozilla/5.0 (compatible; @2bad/ryanair; +https://github.com/2BAD/ryanair)',
+    'client-version': CLIENT_VERSION,
+    cookie: `fr-correlation-id=${randomUUID()}`
   },
   resolveBodyOnly: true,
   responseType: 'json',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,16 +59,9 @@ importers:
       hpagent:
         specifier: 1.2.0
         version: 1.2.0
-      tough-cookie:
-        specifier: 6.0.1
-        version: 6.0.1
       zod:
         specifier: 4.4.3
         version: 4.4.3
-    devDependencies:
-      '@types/tough-cookie':
-        specifier: 4.0.5
-        version: 4.0.5
 
   packages/mcp:
     dependencies:
@@ -1189,9 +1182,6 @@ packages:
 
   '@types/node@25.6.2':
     resolution: {integrity: sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==}
-
-  '@types/tough-cookie@4.0.5':
-    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@vitest/coverage-v8@4.1.5':
     resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
@@ -2443,20 +2433,9 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.0.30:
-    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
-
-  tldts@7.0.30:
-    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
-    hasBin: true
-
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-
-  tough-cookie@6.0.1:
-    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
-    engines: {node: '>=16'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3632,8 +3611,6 @@ snapshots:
   '@types/node@25.6.2':
     dependencies:
       undici-types: 7.19.2
-
-  '@types/tough-cookie@4.0.5': {}
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -4861,17 +4838,7 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.30: {}
-
-  tldts@7.0.30:
-    dependencies:
-      tldts-core: 7.0.30
-
   toidentifier@1.0.1: {}
-
-  tough-cookie@6.0.1:
-    dependencies:
-      tldts: 7.0.30
 
   tree-kill@1.2.2: {}
 


### PR DESCRIPTION
Hardcoded cookie was dead (returned same 409 with or without it). Real auth is just a `fr-correlation-id` cookie (any value) + a `client-version` header matching a current Ryanair build + non-curl UA.

- self-issue `fr-correlation-id` via `randomUUID()`
- default `client-version: 3.196.0`, override via `RYANAIR_CLIENT_VERSION`
- drop unused `tough-cookie`
- README explains the env override

Verified end-to-end against the live API.