### PR TITLE
add live getAvailable test and fix lint warnings

### DIFF
--- a/packages/client/source/airports/integration.test.ts
+++ b/packages/client/source/airports/integration.test.ts
@@ -210,11 +210,12 @@ describe('airports', () => {
 
       expect(data).haveOwnProperty('month')
       expect(data).haveOwnProperty('days')
-      if (data.days.length > 0) {
-        expect(data.days[0]).haveOwnProperty('day')
-        expect(data.days[0]).haveOwnProperty('flights')
-        expect(data.days[0]?.flights[0]).haveOwnProperty('carrierCode')
-      }
+      expect(data.days.length).toBeGreaterThan(0)
+      expect(data.days[0]).haveOwnProperty('day')
+      expect(data.days[0]).haveOwnProperty('flights')
+
+      const dayWithFlights = data.days.find((d) => d.flights.length > 0)
+      expect(dayWithFlights?.flights[0]).haveOwnProperty('carrierCode')
     })
 
     it('should throw HTTP error for non-existing period', async () => {

--- a/packages/client/source/flights/integration.test.ts
+++ b/packages/client/source/flights/integration.test.ts
@@ -111,5 +111,21 @@ describe('flights', () => {
 
       expect(getSpy).toHaveBeenNthCalledWith(1, `${BOOKING_API}/availability?${urlParams.toString()}`)
     })
+
+    it('hits the live booking API and parses real flight data', async () => {
+      const data = await flights.getAvailable({
+        Origin: from,
+        Destination: to,
+        DateOut: flightDate,
+        RoundTrip: 'false'
+      })
+
+      expect(data.trips.length).toBeGreaterThan(0)
+      expect(data.trips[0]?.origin).toBe(from)
+      expect(data.trips[0]?.destination).toBe(to)
+
+      const dayWithFlights = data.trips[0]?.dates.find((d) => d.flights.length > 0)
+      expect(dayWithFlights?.flights[0]?.flightNumber).toMatch(/^[A-Z]{2}\s?\d+$/)
+    })
   })
 })

--- a/packages/client/source/helpers/booking.test.ts
+++ b/packages/client/source/helpers/booking.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 import {
   BookingLinkOptions,
   generateBookingLink,
@@ -39,7 +40,7 @@ describe('BookingLinkOptions', () => {
         destinationIata: 'BER',
         dateOut: '2025-03-30'
       })
-    ).toThrow()
+    ).toThrow(z.ZodError)
 
     // Too long
     expect(() =>
@@ -48,7 +49,7 @@ describe('BookingLinkOptions', () => {
         destinationIata: 'BER',
         dateOut: '2025-03-30'
       })
-    ).toThrow()
+    ).toThrow(z.ZodError)
   })
 
   it('should throw an error for invalid date format', () => {
@@ -60,7 +61,7 @@ describe('BookingLinkOptions', () => {
         destinationIata: 'BER',
         dateOut: '2025/03/30'
       })
-    ).toThrow()
+    ).toThrow(z.ZodError)
   })
 
   it('should throw an error for invalid passenger counts', () => {
@@ -74,7 +75,7 @@ describe('BookingLinkOptions', () => {
         dateOut: '2025-03-30',
         adults: 0
       })
-    ).toThrow()
+    ).toThrow(z.ZodError)
 
     // Teens above maximum
     expect(() =>
@@ -84,7 +85,7 @@ describe('BookingLinkOptions', () => {
         dateOut: '2025-03-30',
         teens: 25
       })
-    ).toThrow()
+    ).toThrow(z.ZodError)
   })
 })
 


### PR DESCRIPTION
- Add a live integration test for `flights.getAvailable` (BER -> VCE, `nextMonth()`). All existing `getAvailable` tests were mocked, which is how the dead cookie went unnoticed.
- Replace bare `.toThrow()` calls in `helpers/booking.test.ts` with `.toThrow(z.ZodError)` (5 sites).
- Fix conditional `expect()` in `airports/integration.test.ts` by asserting `data.days.length > 0` unconditionally and using `find()` for the first day with flights.

Goes from 8 oxlint warnings -> 0. Tests 69 -> 70.