### PR TITLE
bump to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2bad/root",
-  "version": "7.1.2",
+  "version": "8.0.0",
   "private": true,
   "type": "module",
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2bad/ryanair",
-  "version": "7.1.2",
+  "version": "8.0.0",
   "description": "Unofficial typescript client for the Ryanair API that allows you to easily retrieve information about airports, flights and prices.",
   "keywords": [
     "api-client",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2bad/ryanair-mcp",
-  "version": "7.1.2",
+  "version": "8.0.0",
   "description": "Model Context Protocol (MCP) server for Ryanair API with tools for querying flights, fares, airports, and generating booking links",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Bump root + both workspace packages to 8.0.0. CHANGELOG entry already in master (#121). `pnpm -r publish --dry-run` clean for both `@2bad/ryanair` and `@2bad/ryanair-mcp`.