### PR TITLE
publish from github-hosted runner for npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: publish
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read


### PR DESCRIPTION
npm requires github-hosted runners for provenance verification. The Blacksmith migration moved publish.yml to a self-hosted runner, which fails with `422 Unsupported GitHub Actions runner environment` from sigstore when `pnpm publish --provenance` runs. Only the publish job changes; build/test stay on Blacksmith.