### PR TITLE
add dist-tag determination to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,17 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm -r publish --provenance --access public --no-git-checks
+      - name: determine dist-tag
+        id: dist-tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" =~ -([a-zA-Z]+) ]]; then
+            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+      - name: publish
         env:
+          NPM_TAG: ${{ steps.dist-tag.outputs.tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm -r publish --provenance --access public --no-git-checks --tag "$NPM_TAG"


### PR DESCRIPTION
Final piece of publish.yml template alignment: parse prerelease suffix off the root `package.json` version (e.g. `8.1.0-beta.1` -> `beta`, otherwise `latest`) and pass it to `pnpm -r publish --tag`. Matches ts-lib-starter's pattern. No effect on the v8.0.0 release that just went out; prevents accidental `latest` tag on future prereleases.