### PR TITLE
bump to 8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- `flights.getAvailable()` scrapes the current `client-version` from `ryanair.com/ie/en/trip/flights/select` and retries once on `409 Availability declined`. `RYANAIR_CLIENT_VERSION` skips the scrape.
 
 ### Fixed
 
 ### Removed
+
+## [8.1.0] - 2026-08-02
+
+### Changed
+- `flights.getAvailable()` scrapes the current `client-version` from `ryanair.com/ie/en/trip/flights/select` and retries once on `409 Availability declined`. `RYANAIR_CLIENT_VERSION` skips the scrape.
 
 ## [8.0.0] - 2026-05-11
 
@@ -230,7 +234,10 @@ Tools:
 
 ## [1.0.0] - 2023-04-14
 
-[unreleased]: https://github.com/2BAD/ryanair/compare/v7.1.1...HEAD
+[unreleased]: https://github.com/2BAD/ryanair/compare/v8.1.0...HEAD
+[8.1.0]: https://github.com/2BAD/ryanair/compare/v8.0.0...v8.1.0
+[8.0.0]: https://github.com/2BAD/ryanair/compare/v7.1.2...v8.0.0
+[7.1.2]: https://github.com/2BAD/ryanair/compare/v7.1.1...v7.1.2
 [7.1.1]: https://github.com/2BAD/ryanair/compare/v7.1.0...v7.1.1
 [7.1.0]: https://github.com/2BAD/ryanair/compare/v7.0.0...v7.1.0
 [7.0.0]: https://github.com/2BAD/ryanair/compare/v6.0.1...v7.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2bad/root",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": true,
   "type": "module",
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2bad/ryanair",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Unofficial typescript client for the Ryanair API that allows you to easily retrieve information about airports, flights and prices.",
   "keywords": [
     "api-client",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2bad/ryanair-mcp",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Model Context Protocol (MCP) server for Ryanair API with tools for querying flights, fares, airports, and generating booking links",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Releases the client-version self-recovery work: getAvailable() now scrapes the live version and retries once on 409 instead of surfacing the error. No public API change, so minor.