### PR TITLE
publish to npm via trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,5 +37,4 @@ jobs:
       - name: publish
         env:
           NPM_TAG: ${{ steps.dist-tag.outputs.tag }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm -r publish --provenance --access public --no-git-checks --tag "$NPM_TAG"


### PR DESCRIPTION
The npm automation token expired, and pnpm kept presenting it instead of falling back to OIDC, so publishing 8.1.0 failed with a misleading 404 on the token exchange. Trusted publishing is now configured on npmjs.com for both packages; dropping NODE_AUTH_TOKEN leaves OIDC as the only auth source. The NPM_TOKEN secret has been deleted.